### PR TITLE
Various improvements

### DIFF
--- a/Californium/Entity.cs
+++ b/Californium/Entity.cs
@@ -47,22 +47,69 @@ namespace Californium
         /// </summary>
         public virtual FloatRect BoundingBox
         {
-            get { return new FloatRect(Position.X - (Origin.X * Scale.X), Position.Y - (Origin.Y * Scale.Y), Size.X * Scale.X, Size.Y * Scale.Y); }
+            get
+            {
+                return new FloatRect(
+                    Position.X - (Origin.X * Scale.X),
+                    Position.Y - (Origin.Y * Scale.Y),
+                    Size.X * Scale.X, 
+                    Size.Y * Scale.Y
+                );
+            }
         }
 
         /// <summary>
         /// Called when the Entity is being added to an EntityManager.
         /// Unlike the constructor, Parent is valid when Create is called.
         /// </summary>
-        public virtual void Create() { }
+        public virtual void Create()
+        {
+            
+        }
 
         /// <summary>
         /// Called when the Entity is being removed from an EntityManager.
         /// Parent is valid when Destroy is called.
         /// </summary>
-        public virtual void Destroy() { }
+        public virtual void Destroy()
+        {
+            
+        }
 
-        public virtual void Update() { }
-        public virtual void Draw(RenderTarget rt) { }
+        /// <summary>
+        /// Called one or more times before Draw depending on the current delta.
+        /// This will be called as many times as required to keep the update loop
+        /// in sync with expected time.
+        /// </summary>
+        public virtual void Update()
+        {
+            
+        }
+
+        /// <summary>
+        /// Called once per frame.
+        /// </summary>
+        /// <param name="rt">RenderTarget, passed from engine.</param>
+        public virtual void Draw(RenderTarget rt)
+        {
+            
+        }
+
+        /// <summary>
+        /// Draws a rectangle around the entity as its computed bounding box.
+        /// If any collision is detected the box will be opaque, otherwise it is drawn transparently.
+        /// </summary>
+        /// <param name="rt">RenderTarget, passed from engine.</param>
+        /// <param name="color">Color of bounding box.</param>
+        protected void DrawBoundingBox(RenderTarget rt, Color color)
+        {
+            RectangleShape boundingBox = new RectangleShape(new Vector2f(BoundingBox.Width, BoundingBox.Height))
+            {
+                Position = new Vector2f(BoundingBox.Left, BoundingBox.Top),
+                FillColor = Parent.Entities.PlaceFree(BoundingBox) ? color : new Color(color.R, color.G, color.B, 128)
+            };
+
+            rt.Draw(boundingBox);
+        }
     }
 }

--- a/Californium/EntityManager.cs
+++ b/Californium/EntityManager.cs
@@ -54,7 +54,7 @@ namespace Californium
                 newGridPos.X = (int)e.Position.X / GameOptions.EntityGridSize;
                 newGridPos.Y = (int)e.Position.Y / GameOptions.EntityGridSize;
 
-                if (!e.GridCoordinate.Equals(newGridPos))
+                if (entities.Contains(e) && !e.GridCoordinate.Equals(newGridPos))
                 {
                     GridRemove(e);
                     e.GridCoordinate = newGridPos;
@@ -86,7 +86,9 @@ namespace Californium
             // DepthRandomize helps make depth more consistent by eliminating entities with the same depth value
             foreach (var e in InArea(screenBounds).OrderBy(e => (float)e.Depth + e.DepthRandomize))
             {
+                currentEntity = e;
                 e.Draw(rt);
+                currentEntity = null;
             }
         }
 
@@ -143,9 +145,9 @@ namespace Californium
 
             var pos = new Vector2i();
 
-            for (var y = startY; y < startY + height; y++)
+            for (var y = startY; y <= startY + height; y++)
             {
-                for (var x = startX; x < startX + width; x++)
+                for (var x = startX; x <= startX + width; x++)
                 {
                     pos.X = x;
                     pos.Y = y;
@@ -170,6 +172,11 @@ namespace Californium
             return InArea(rect).All(entity => entity == currentEntity || !entity.Solid || !entity.BoundingBox.Intersects(rect));
         }
 
+        public bool CollidingWith<T>(FloatRect rect)
+        {
+            return InArea(rect).Any(e => e is T && e.BoundingBox.Intersects(rect));
+        }
+
         public IEnumerator<Entity> GetEnumerator()
         {
             var cur = entities.First;
@@ -190,6 +197,7 @@ namespace Californium
         {
             if (inputEntities.Contains(e))
                 return;
+
             inputEntities.Add(e);
         }
 

--- a/Californium/EntityManager.cs
+++ b/Californium/EntityManager.cs
@@ -54,9 +54,8 @@ namespace Californium
                 newGridPos.X = (int)e.Position.X / GameOptions.EntityGridSize;
                 newGridPos.Y = (int)e.Position.Y / GameOptions.EntityGridSize;
 
-                if (entities.Contains(e) && !e.GridCoordinate.Equals(newGridPos))
+                if (!e.GridCoordinate.Equals(newGridPos) && GridRemove(e))
                 {
-                    GridRemove(e);
                     e.GridCoordinate = newGridPos;
                     GridAdd(e);
                 }
@@ -216,12 +215,14 @@ namespace Californium
             list.AddLast(e);
         }
 
-        private void GridRemove(Entity e)
+        private bool GridRemove(Entity e)
         {
             LinkedList<Entity> list;
 
             if (entityGrid.TryGetValue(e.GridCoordinate, out list))
-                list.Remove(e);
+                return list.Remove(e);
+
+            return false;
         }
     }
 }

--- a/Californium/Input.cs
+++ b/Californium/Input.cs
@@ -6,6 +6,9 @@ namespace Californium
 {
     public class Input
     {
+        public const bool Continue = true;
+        public const bool Block = false;
+
         public delegate bool KeyEvent(KeyInputArgs args);
         public delegate bool TextEvent(TextInputArgs args);
         public delegate bool MouseButtonEvent(MouseButtonInputArgs args);

--- a/Californium/Utility.cs
+++ b/Californium/Utility.cs
@@ -8,6 +8,34 @@ namespace Californium
 {
     public static class Utility
     {
+        public static FloatRect Translate(this FloatRect value, float x, float y)
+        {
+            return new FloatRect(value.Left + x, value.Top + y, value.Width, value.Height);
+        }
+
+        public static Vector2f Rotate(this Vector2f value, Vector2f origin, float theta)
+        {
+            return new Vector2f(
+                (float)Math.Cos(theta) * (value.X - origin.X) - (float)Math.Sin(theta) * (value.Y - origin.Y) + origin.X,
+                (float)Math.Sin(theta) * (value.X - origin.X) + (float)Math.Cos(theta) * (value.Y - origin.Y) + origin.Y
+            );
+        }
+
+        public static Vector2f ToFloat(this Vector2u value)
+        {
+            return new Vector2f(value.X, value.Y);
+        }
+
+        public static Vector2u ToUnsigned(this Vector2f value)
+        {
+            return new Vector2u((uint)value.X, (uint)value.Y);
+        }
+
+        public static float Lerp(float a, float b, float w)
+        {
+            return a + w * (b - a);
+        }
+
         public static float Clamp(float value, float min, float max)
         {
             return (value < min) ? min : ((value > max) ? max : value);
@@ -82,6 +110,14 @@ namespace Californium
         {
             trans.Position = new Vector2f((float)Math.Round(trans.Position.X), (float)Math.Round(trans.Position.Y));
             trans.Origin = new Vector2f((float)Math.Round(trans.Origin.X), (float)Math.Round(trans.Origin.Y));
+        }
+
+        public static Vector2f Round(this Vector2f value)
+        {
+            return new Vector2f(
+                (float)Math.Round(value.X),
+                (float)Math.Round(value.Y)
+            );
         }
     }
 }


### PR DESCRIPTION
This pull request makes the Californium engine friendlier to use for games that deal heavily in collisions.

### Bug Fixes
- Fix bug where engine would not report the existence of an entity in a bucket when it existed on the border of that bucket.

### Additions
- Block/Continue constants in Input to make distinguishing the requested action at the end of an input event handler easier.
- Add a method to draw a debug bounding box for an entity
- Add some collision helper methods
- Add several new Utility methods, including methods to cast between Vector2* types easily.
- Add support for collision methods inside of Draw methods, which is occasionally useful when you don't want to pass booleans between the Update and Draw methods in the class.

### Other
- Document a few methods in Entity.