### PR TITLE
Add built-in framerate calculation.

### DIFF
--- a/Californium/Game.cs
+++ b/Californium/Game.cs
@@ -26,6 +26,8 @@ namespace Californium
             get { return new Stack<State>(StateStack); }
         }
 
+        public static float Framerate { get; private set; }
+
         /// <summary>
         /// Function to call when the game is lagging. Provides the amount of time that was dropped.
         /// </summary>
@@ -36,6 +38,10 @@ namespace Californium
 
         private static Vector2f size;
         private static bool running;
+
+        private static float frameTime;
+        private static float lastFrameTime;
+        private static Stopwatch frameTimer;
 
         static Game()
         {
@@ -56,7 +62,11 @@ namespace Californium
             running = true;
 
             Window = new RenderWindow(new VideoMode(GameOptions.Width, GameOptions.Height), GameOptions.Caption, style);
-            Window.SetFramerateLimit(GameOptions.Framerate);
+            
+            // NOTE It appears that SFML's framerate limiter is inaccurate, it's always half the speed specified.
+            //      This hack is to get around that and request the expected framerate. Because of the way that updating
+            //      is handled this will not affect the timing of anything.
+            Window.SetFramerateLimit(GameOptions.Framerate << 1);
             Window.SetVerticalSyncEnabled(GameOptions.Vsync);
 
             if (!string.IsNullOrWhiteSpace(GameOptions.Icon))
@@ -64,7 +74,9 @@ namespace Californium
                 var icon = Assets.LoadTexture(GameOptions.Icon);
                 Window.SetIcon(icon.Size.X, icon.Size.Y, icon.CopyToImage().Pixels);
             }
-            
+
+            Framerate = GameOptions.Framerate;
+
             #region Event Wrappers
             Window.Closed += (sender, args) => Exit(true);
             Window.Resized += (sender, args) => Resize(new Vector2f(args.Width, args.Height));
@@ -98,6 +110,10 @@ namespace Californium
         {
             var timer = new Stopwatch();
             double accumulator = 0;
+
+            frameTimer = new Stopwatch();
+            frameTimer.Restart();
+            lastFrameTime = frameTimer.ElapsedMilliseconds;
 
             while (running)
             {
@@ -149,6 +165,17 @@ namespace Californium
                 #endregion
 
                 Window.Display();
+
+                // Calculate framerate
+                float currentFrameTime = 1000.0f / ((frameTime = frameTimer.ElapsedMilliseconds) - lastFrameTime);
+                if (Math.Abs(frameTime - lastFrameTime) > float.Epsilon)
+                {
+                    // NOTE The 50 is not in reference to 50 fps, it's in reference quickly to
+                    //      tween between framerates, to prevent sudden jumps that occur fairly
+                    //      often.
+                    Framerate += (currentFrameTime - Framerate) / 50;
+                    lastFrameTime = frameTime;
+                }
             }
 
             while (StateStack.Count > 0)

--- a/Californium/Game.cs
+++ b/Californium/Game.cs
@@ -62,11 +62,7 @@ namespace Californium
             running = true;
 
             Window = new RenderWindow(new VideoMode(GameOptions.Width, GameOptions.Height), GameOptions.Caption, style);
-            
-            // NOTE It appears that SFML's framerate limiter is inaccurate, it's always half the speed specified.
-            //      This hack is to get around that and request the expected framerate. Because of the way that updating
-            //      is handled this will not affect the timing of anything.
-            Window.SetFramerateLimit(GameOptions.Framerate << 1);
+            Window.SetFramerateLimit(GameOptions.Framerate);
             Window.SetVerticalSyncEnabled(GameOptions.Vsync);
 
             if (!string.IsNullOrWhiteSpace(GameOptions.Icon))

--- a/todo.md
+++ b/todo.md
@@ -1,15 +1,8 @@
-Documentation
-
-Builtin Framerate calculation
-
-Particle engine
-
-Resource unloading
-
-Window size constraints
-
-Make events function like all other libraries (use real events, cancel from EventArgs)
-
-Improve tweening
-
-GUI
+## Todo List
+- Documentation
+- Particle engine
+- Resource unloading
+- Window size constraints
+- Make events function like all other libraries (use real events, cancel from EventArgs)
+- Improve tweening
+- GUI


### PR DESCRIPTION
This knocks one of the items off the todo list and fixes a minor issue related to SFML.

### Additions
- Add built-in framerate calculation.

### Bug Fixes
- Fix requesting half the framerate than what was expected.